### PR TITLE
Update searchRules() to remove bug

### DIFF
--- a/launchpy/property.py
+++ b/launchpy/property.py
@@ -258,9 +258,9 @@ class Property:
         """
         filters = {}
         if name != None:
-            filters['filter[name]=CONTAINS '] = f"EQ {name}"
+            filters['filter[name]'] = f"EQ {name}"
         if name_contains != None:
-            filters['filter[name]=CONTAINS '] = f"CONTAINS {name_contains}"
+            filters['filter[name]'] = f"CONTAINS {name_contains}"
         if dirty != None:
             filters['filter[dirty]'] = f"EQ {str(dirty).lower()}"
         if enabled != None:


### PR DESCRIPTION
The filter dict had a typo in the keys for name filtering. Removed =CONTAINS from the keys set.