### PR TITLE
Fix syntax in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ PyJWT[crypto]>=1.7.1
 PyJWT>=1.7.1
 pathlib2>=2.3.5
 requests>=2.25.0
-aepp=>0.3.10
+aepp>=0.3.10
 pandas>=2.1.0


### PR DESCRIPTION
Swap the greater than and equals sign as it was throwing an error why trying to install packages